### PR TITLE
Add climbing area, crag and boulder to be recognized as areas

### DIFF
--- a/polygon-features.json
+++ b/polygon-features.json
@@ -153,5 +153,14 @@
     {
         "key": "indoor",
         "polygon": "all"
+    },
+    {
+        "key": "climbing",
+        "polygon": "whitelist",
+        "values": [
+            "area",
+            "crag",
+            "boulder"
+        ]
     }
 ]


### PR DESCRIPTION
Hi, 

I added `climbing=area`, `climbing=crag` and `climbing=boulder` as being areas too - partly in function of my [Open Climbing Map](https://mapcomplete.osm.be/climbing).

Kind regards,
Pieter