### PR TITLE
Drop 'barrier=wall' from whitelist (fix #7)

### DIFF
--- a/polygon-features.json
+++ b/polygon-features.json
@@ -54,7 +54,6 @@
             "ditch",
             "hedge",
             "retaining_wall",
-            "wall",
             "spikes"
         ]
     },


### PR DESCRIPTION
In this issue https://github.com/tyrasd/osm-polygon-features/issues/7 it was mentioned that we need to drop `barrier=wall` tag from the whitelist of polygons. And that's correct according to the OSM wiki https://wiki.openstreetmap.org/wiki/Tag:barrier=wall#Mapping_as_an_area. Also, I have an issue in `osm2geojson`  mentioned here https://github.com/aspectumapp/osm2geojson/issues/7#issuecomment-1967830306